### PR TITLE
Install beats as a service

### DIFF
--- a/beats/init.sls
+++ b/beats/init.sls
@@ -3,3 +3,4 @@ include:
   - .repo
   - .install
   - .conf
+  - .service

--- a/beats/service.sls
+++ b/beats/service.sls
@@ -1,0 +1,19 @@
+# Install beats as a service
+{% set beats = salt['pillar.get']('beats:packages', []) %}
+
+# Loop through the supported beats
+{%- for current in ['filebeat', 'topbeat', 'packetbeat'] %}
+
+{%- if current in beats %}
+extend:
+  {{ current }}:
+    service.running:
+      - enable: True
+      - watch:
+        - pkg: {{ current }}
+      - require:
+        - pkg: {{ current }}
+
+{% endif %}
+
+{% endfor %}


### PR DESCRIPTION
## What

The beats were being installed and configured, but the beats weren't being started as a service by default. That is however the expected behaviour, and this PR will accomplish that.
